### PR TITLE
add lisp

### DIFF
--- a/lisp.svg
+++ b/lisp.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg1130"
+   version="1.1"
+   viewBox="0 0 150.67032 63.430981"
+   height="63.430981mm"
+   width="150.67032mm"
+   sodipodi:docname="lisp.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:export-filename="/home/user/projects/src/github.com/mkrl/misbrands/lisp.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="false"
+     inkscape:document-units="mm"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="257.38687"
+     inkscape:cy="164.04877"
+     inkscape:window-width="1918"
+     inkscape:window-height="1032"
+     inkscape:window-x="1920"
+     inkscape:window-y="23"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1130"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <defs
+     id="defs1124" />
+  <metadata
+     id="metadata1127">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-42.309267,-55.036301)"
+     id="layer1">
+    <path
+       id="rect1143"
+       d="m 50.191767,71.013753 v 31.713317 7.84913 H 65.874015 83.385829 V 94.888401 H 65.857183 V 71.022369 Z"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#cb3837;stroke-width:15.765;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       transform="scale(0.26458333)"
+       id="path1168"
+       d="m 404.15234,284.95117 h -59.21093 v 103.06836 h 59.21093 z"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#cb3837;stroke-width:60.0244;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill" />
+    <path
+       transform="scale(0.26458333)"
+       id="rect1161"
+       d="m 344.94141,238.02344 v 30.375 h 59.21093 v -30.375 z"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#cb3837;stroke-width:60.0244;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill" />
+    <path
+       id="rect1143-1"
+       d="m 153.43786,71.022369 v 31.713281 7.84913 h 15.68234 v -7.84913 h 15.97689 V 71.022369 Z m 15.83582,7.951447 h 7.85124 v 15.8688 h -7.85124 z"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#cb3837;stroke-width:15.765;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill" />
+    <path
+       id="rect1143-1-3"
+       d="m 114.8591,71.022369 v 31.713271 7.84913 h 15.68234 l 15.97622,-0.009 6.7e-4,-39.553831 z m 15.83582,7.951447 15.82274,4.11e-4 v 8.026285 0 h -10.44281 -5.37822 z m -15.83608,15.914585 15.83779,3.9e-5 v 8.02629 0 l -10.44282,-0.004 -5.39497,0.004 z"
+       style="fill:#ffffff;fill-opacity:1;stroke:#cb3837;stroke-width:15.765;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       sodipodi:nodetypes="ccccccccccccccccccccc" />
+  </g>
+</svg>


### PR DESCRIPTION
because it has red&white logo before it became mainstream https://wilkesley.org/~ian/xah/emacs/lisp_logo.html

![image](https://user-images.githubusercontent.com/747362/148317687-0026c290-f268-4c34-8ce9-bb87d90e0a87.png)
